### PR TITLE
fix sample docker run in README

### DIFF
--- a/samba/README.md
+++ b/samba/README.md
@@ -16,7 +16,7 @@ the volumes attached to the specified container.
 $ docker run svendowideit/samba
 
 please run with
-   docker run --rm -v $(which docker):/docker -v /run/docker.sock:/docker.sock svendowideit/samba <container_name>
+   docker run --rm -v $(which docker):/docker -v /var/run/docker.sock:/docker.sock svendowideit/samba <container_name>
 ```
 
 ## How it works


### PR DESCRIPTION
I'm lazy so copy pasted the `docker run ...` sample from the _Usage_ section, and it didn't work.
