### PR TITLE
Fix default permissions on new files

### DIFF
--- a/samba/share.tmpl
+++ b/samba/share.tmpl
@@ -6,4 +6,6 @@
   force user = ${USER}
   force group = ${GROUP}
   guest ok = yes
-
+  map archive = no
+  map system = no
+  map hidden = no


### PR DESCRIPTION
Add map archive/system/hidden = no so that the samba shares behave in a more unix-like manner by default