### PR TITLE
Check if /docker exists

### DIFF
--- a/samba/setup.sh
+++ b/samba/setup.sh
@@ -68,6 +68,10 @@ if [ "$container" = "/bin/sh" -o "$container" = "/bin/bash" ]; then
 	usage
 fi
 
+if [ ! -x /docker ]; then
+	usage
+fi
+
 docker="/docker -H ${DOCKER_HOST} "
 
 # Test for docker socket and client


### PR DESCRIPTION
Executing `docker run svendowideit/samba` prints out an error message "/setup.sh: line 74: /docker: No such file or directory" before the usage. Checking if /docker exists and is executable before using it should get rid of this error message.