### PR TITLE
Change VOLUME_NAME to remove all /

### DIFF
--- a/samba/setup.sh
+++ b/samba/setup.sh
@@ -28,7 +28,7 @@ if [ "$container" = "--start" ]; then
 		echo "add $vol"
 		export VOLUME=$vol
 
-		export VOLUME_NAME=$(echo $VOLUME | sed "s/\///")
+		export VOLUME_NAME=$(echo $VOLUME | sed "s/\///g")
 
 		cat /share.tmpl | envsubst >> /etc/samba/smb.conf
 	done


### PR DESCRIPTION
VOLUME_NAME now gets all / characters removed (instead of just the first), which will allow access to volumes that are more than one directory deep, to fix #8 .

