### PR TITLE
Updated how the samba container id is being fetched.

### DIFF
--- a/samba/setup.sh
+++ b/samba/setup.sh
@@ -92,7 +92,7 @@ if ! $docker inspect --format="{{range \$k,\$v := .Volumes}}{{println \$k}}{{end
 	usage
 fi
 
-sambaContainer=`grep cpu: /proc/1/cgroup  | sed 's/.*\docker\///'`
+sambaContainer=`grep cpu[^a-zA-Z\d] /proc/1/cgroup |grep -oE '[0-9a-fA-F]{64}'`
 sambaImage=`$docker inspect --format="{{.Config.Image}}" $sambaContainer`
 #echo "$sambaContainer running using $sambaImage"
 


### PR DESCRIPTION
I ran into a issue on my install of debian jessie where the container would fail to start due to `sambaContainer` returning empty. 

It turns out that `/proc/1/cgroup` is formated a bit differently on my host.
```
3:cpu,cpuacct:/system.slice/docker-5d55e2c82e9782e76a993b1edaa958817a4e99457756c8acef923e8c1e9fee21.scope
```
I verified that the changes work with the current boo2docker vm along with the previous match `grep cpu: /proc/1/cgroup | sed 's/.*\docker\///'`