### PR TITLE
Update ambassador image

### DIFF
--- a/ambassador/Dockerfile
+++ b/ambassador/Dockerfile
@@ -1,18 +1,19 @@
 #
-#
-# first you need to build the docker-ut image using ./contrib/mkimage-unittest.sh
-# then 
-#   docker build -t SvenDowideit/ambassador .
-#   docker tag SvenDowideit/ambassador ambassador
+# do
+#   docker build -t svendowideit/ambassador .
 # then to run it (on the host that has the real backend on it)
-#   docker run -t -i -link redis:redis -name redis_ambassador -p 6379:6379 ambassador
+#   docker run -t -i -link redis:redis -name redis_ambassador -p 6379:6379 svendowideit/ambassador
 # on the remote host, you can set up another ambassador
-#    docker run -t -i -name redis_ambassador -expose 6379 -e REDIS_PORT_6379_TCP=tcp://192.168.1.52:6379 ambassador sh
+#    docker run -t -i -name redis_ambassador -expose 6379 -e REDIS_PORT_6379_TCP=tcp://192.168.1.52:6379 svendowideit/ambassador sh
+# you can read more about this process at https://docs.docker.com/articles/ambassador_pattern_linking/
 
-# use docker-ut because its a simple busybox image with socat added.
+# use alpine because its a minimal image with a package manager.
 # prettymuch all that is needed is a container that has a functioning env and socat (or equivalent)
-FROM	docker-ut
+FROM	alpine:3.2
 MAINTAINER	SvenDowideit@home.org.au
 
+RUN apk update && \
+	apk add socat && \
+	rm -r /var/cache/
 
-CMD	env | grep _TCP= | sed 's/.*_PORT_\([0-9]*\)_TCP=tcp:\/\/\(.*\):\(.*\)/socat TCP4-LISTEN:\1,fork,reuseaddr TCP4:\2:\3 \&/'  | sh && top
+CMD	env | grep _TCP= | sed 's/.*_PORT_\([0-9]*\)_TCP=tcp:\/\/\(.*\):\(.*\)/socat -t 100000000 TCP4-LISTEN:\1,fork,reuseaddr TCP4:\2:\3 \& wait/' | sh


### PR DESCRIPTION
This image

 - can be used as an automated build (no need to build docker-ut yourself)
 - uses the `-t` argument to socat (#16602)
 - does not pointlessly run top