### PR TITLE
Ambassador fix to allow multiple ports

### DIFF
--- a/ambassador/Dockerfile
+++ b/ambassador/Dockerfile
@@ -16,4 +16,4 @@ RUN apk update && \
 	apk add socat && \
 	rm -r /var/cache/
 
-CMD	env | grep _TCP= | sed 's/.*_PORT_\([0-9]*\)_TCP=tcp:\/\/\(.*\):\(.*\)/socat -t 100000000 TCP4-LISTEN:\1,fork,reuseaddr TCP4:\2:\3 \& wait/' | sh
+CMD	env | grep _TCP= | (sed 's/.*_PORT_\([0-9]*\)_TCP=tcp:\/\/\(.*\):\(.*\)/socat -t 100000000 TCP4-LISTEN:\1,fork,reuseaddr TCP4:\2:\3 \&/' && echo wait) | sh


### PR DESCRIPTION
The little shell script in the ambassador image breaks if there are multiple ports that need to be forwarded. The problem is that you have a `wait` after every `socat` line, and then the script stops running at the first `wait` and the other ports won't be forwarded. 

This came up in the `dokku-rabbitmq` project, that exposes 4 ports using the ambassador image:
https://github.com/dokku/dokku-rabbitmq/issues/27

This is the problematic line: https://github.com/SvenDowideit/dockerfiles/blob/5bfe59de304fe6f1489e42ddceb37bb980f38a9e/ambassador/Dockerfile#L19

My fix calls `wait` only once, after all `socat` processes have started in the background.

So I guess whether you want this fix depends on whether you want to support multiple ports. If not, then I suggest to document this somewhere, because it causes a lot of confusion and delay. :)
